### PR TITLE
Color the keywords extends and tranforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "vscode": "^1.13.0"
     },
     "categories": [
-        "Languages"
+        "Programming Languages"
     ],
     "contributes": {
         "languages": [{

--- a/syntaxes/c3typ.tmLanguage.json
+++ b/syntaxes/c3typ.tmLanguage.json
@@ -141,7 +141,12 @@
     {
       "comment": "extends",
       "match": "\\b(extends)\\b",
-      "name": "keyword.operator.c3typ"
+      "name": "keyword.control.block.c3typ"
+    },
+    {
+      "comment": "transforms",
+      "match": "\\b(transforms)\\b",
+      "name": "keyword.control.block.c3typ"
     },
     {
       "comment": "scratches",
@@ -211,7 +216,7 @@
       "name": "entity.name.function.c3typ"
     },
     {
-      "comment": false,
+      "comment": "required",
       "match": "\\!",
       "name": "keyword.operator.required.c3typ"
     },


### PR DESCRIPTION
The keyword `transforms` was missing.
The keyword `extends` was not colorized.
This PR fix these issues.